### PR TITLE
Add dynamic video page

### DIFF
--- a/src/app/videos/[videoId]/page.tsx
+++ b/src/app/videos/[videoId]/page.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import React, { useEffect, useState } from 'react'
+import { useParams } from 'next/navigation'
+import VideoPlayer from '@/components/VideoPlayer/VideoPlayer'
+import { doc, getDoc } from 'firebase/firestore'
+import { db } from '../../firebase'
+import type { VideoDoc } from '@/types/index.types'
+import type { Language } from '@/components/LanguageMetaForm'
+
+export default function VideoViewPage() {
+  const { videoId } = useParams<{ videoId: string }>()
+  const [videoDoc, setVideoDoc] = useState<VideoDoc | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!videoId) return
+    ;(async () => {
+      try {
+        const docRef = doc(db, 'videos', videoId)
+        const snap = await getDoc(docRef)
+        if (!snap.exists()) {
+          throw new Error('Видео не найдено')
+        }
+        const d = snap.data() as any
+        const loaded: VideoDoc = {
+          src: d.src as string,
+          previewSrc: d.previewSrc as string,
+          originalLang: d.originalLang as Language,
+          targetLangs: d.targetLangs as Language[],
+          difficulty: d.difficulty as string,
+          tags: d.tags as string[],
+          subtitle: d.subtitle as any,
+          name: d.name as string,
+          size: d.size as number,
+          updated: d.updated || null,
+        }
+        setVideoDoc(loaded)
+      } catch (e: any) {
+        console.error(e)
+        setError(e.message)
+      }
+    })()
+  }, [videoId])
+
+  if (error) {
+    return <p className="text-red-600">Ошибка: {error}</p>
+  }
+  if (!videoDoc) {
+    return <p className="text-gray-500">Загрузка видео…</p>
+  }
+
+  return (
+    <div className="flex justify-center p-4">
+      <VideoPlayer
+        src={videoDoc.src}
+        subtitles={videoDoc.subtitle}
+        originalLang={videoDoc.originalLang}
+      />
+    </div>
+  )
+}

--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -1,19 +1,18 @@
-import React from 'react';
-// import { useNavigate } from 'react-router-dom';
-import type { VideoMeta } from '@/types/video.types';
+import React from 'react'
+import Link from 'next/link'
+import type { VideoMeta } from '@/types/video.types'
 
 interface Props {
   video: VideoMeta;
 }
 
 export default function VideoCard({ video }: Props) {
-  // const navigate = useNavigate();
 
   return (
     <div className="relative group">
       {/* Обёртка с кликом по превью */}
-      <div
-        // onClick={() => navigate(`/video/${video.videoId}`, { state: { videoUrl: video.videoUrl } })}
+      <Link
+        href={`/videos/${video.videoId}`}
         className="space-y-2 transition cursor-pointer hover:opacity-90"
       >
         <video
@@ -29,7 +28,7 @@ export default function VideoCard({ video }: Props) {
             {video.updated ? new Date(video.updated).toLocaleString() : '—'}
           </p>
         </div>
-      </div>
+      </Link>
 
       {/* Кнопка "Редактировать" */}
       <button


### PR DESCRIPTION
## Summary
- link each video card to its own page
- add `[videoId]` route fetching the video data from Firestore

## Testing
- `npm run lint` *(fails: several lint errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68454316ae64832f9f0c9cc6a53024f2