### PR TITLE
Add back button on video page

### DIFF
--- a/src/app/videos/[videoId]/page.tsx
+++ b/src/app/videos/[videoId]/page.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import React, { useEffect, useState } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import VideoPlayer from '@/components/VideoPlayer/VideoPlayer'
+import { doc, getDoc } from 'firebase/firestore'
+import { db } from '../../firebase'
+import type { VideoDoc } from '@/types/index.types'
+
+export default function VideoViewPage() {
+  const { videoId } = useParams<{ videoId: string }>()
+  const router = useRouter()
+  const [videoDoc, setVideoDoc] = useState<VideoDoc | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!videoId) return
+    ;(async () => {
+      try {
+        const docRef = doc(db, 'videos', videoId)
+        const snap = await getDoc(docRef)
+        if (!snap.exists()) {
+          throw new Error('Видео не найдено')
+        }
+        const data = snap.data() as VideoDoc
+        setVideoDoc({ ...data, updated: data.updated ?? null })
+      } catch (e: unknown) {
+        console.error(e)
+        setError(e instanceof Error ? e.message : 'Unknown error')
+      }
+    })()
+  }, [videoId])
+
+  const handleBack = () => {
+    if (typeof window !== 'undefined' && window.history.length > 1) {
+      router.back()
+    } else {
+      router.push('/videos')
+    }
+  }
+
+  if (error) {
+    return <p className="text-red-600">Ошибка: {error}</p>
+  }
+  if (!videoDoc) {
+    return <p className="text-gray-500">Загрузка видео…</p>
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-4 p-4">
+      <button
+        onClick={handleBack}
+        className="self-start px-4 py-2 text-gray-700 bg-gray-300 rounded"
+      >
+        Назад
+      </button>
+      <VideoPlayer
+        src={videoDoc.src}
+        subtitles={videoDoc.subtitle}
+        originalLang={videoDoc.originalLang}
+      />
+    </div>
+  )
+}

--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -1,19 +1,18 @@
-import React from 'react';
-// import { useNavigate } from 'react-router-dom';
-import type { VideoMeta } from '@/types/video.types';
+import React from 'react'
+import Link from 'next/link'
+import type { VideoMeta } from '@/types/video.types'
 
 interface Props {
   video: VideoMeta;
 }
 
 export default function VideoCard({ video }: Props) {
-  // const navigate = useNavigate();
 
   return (
     <div className="relative group">
       {/* Обёртка с кликом по превью */}
-      <div
-        // onClick={() => navigate(`/video/${video.videoId}`, { state: { videoUrl: video.videoUrl } })}
+      <Link
+        href={`/videos/${video.videoId}`}
         className="space-y-2 transition cursor-pointer hover:opacity-90"
       >
         <video
@@ -29,7 +28,7 @@ export default function VideoCard({ video }: Props) {
             {video.updated ? new Date(video.updated).toLocaleString() : '—'}
           </p>
         </div>
-      </div>
+      </Link>
 
       {/* Кнопка "Редактировать" */}
       <button


### PR DESCRIPTION
## Summary
- add navigation back button on `[videoId]` video page
- load Firestore doc without `any`

## Testing
- `npm run lint` *(fails: many existing errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68454316ae64832f9f0c9cc6a53024f2