### PR TITLE
Add exercises pages for Next.js

### DIFF
--- a/src/app/exercises/[exerciseId]/page.tsx
+++ b/src/app/exercises/[exerciseId]/page.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import React, { useEffect, useState } from 'react'
+import { useParams } from 'next/navigation'
+import { doc, getDoc } from 'firebase/firestore'
+import { db } from '@/app/firebase'
+import SentenceExercise from '@/components/SentenceExercise'
+import type { Exercise } from '@/types/index.types'
+
+export default function ExercisePage() {
+  const { exerciseId } = useParams<{ exerciseId: string }>()
+  const [exercise, setExercise] = useState<Exercise | null>(null)
+  const [currentIndex, setCurrentIndex] = useState(0)
+
+  useEffect(() => {
+    if (!exerciseId) return
+    ;(async () => {
+      const snap = await getDoc(doc(db, 'exercises', exerciseId))
+      if (snap.exists()) {
+        setExercise(snap.data() as Exercise)
+      }
+    })()
+  }, [exerciseId])
+
+  const total = exercise?.sentences.length ?? 0
+
+  const handleComplete = () => {
+    setCurrentIndex(prev => Math.min(prev + 1, total))
+  }
+
+  if (!exercise) {
+    return <p className="p-4">Загрузка...</p>
+  }
+
+  return (
+    <div className="max-w-2xl p-6 mx-auto space-y-6">
+      <h1 className="text-2xl font-bold">{exercise.title}</h1>
+      <p className="mb-4 text-gray-600">{exercise.description}</p>
+      <p className="mb-4 text-gray-600">
+        Тема: {exercise.topic}; Уровень:{' '}
+        <span className="font-semibold capitalize">{exercise.difficulty}</span>
+      </p>
+
+      <div className="w-full h-4 mb-2 overflow-hidden bg-gray-200 rounded">
+        <div
+          className="h-full transition-all bg-green-500"
+          style={{ width: `${(currentIndex / total) * 100}%` }}
+        />
+      </div>
+      <p className="text-sm text-right text-gray-700">
+        Задание {Math.min(currentIndex + 1, total)} из {total}
+      </p>
+
+      {exercise.sentences.map((sent, idx) => (
+        <SentenceExercise
+          key={idx}
+          sentence={sent}
+          index={idx}
+          isActive={idx <= currentIndex}
+          onComplete={handleComplete}
+        />
+      ))}
+
+      {currentIndex >= total && (
+        <div className="p-4 text-blue-900 bg-blue-100 rounded">
+          <p className="font-medium">Поздравляем! Вы прошли все задания урока.</p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/exercises/page.tsx
+++ b/src/app/exercises/page.tsx
@@ -1,5 +1,71 @@
+"use client"
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { collection, deleteDoc, doc, getDocs } from 'firebase/firestore'
+import { db } from '@/app/firebase'
+import type { Exercise } from '@/types/index.types'
+
+interface ExerciseWithId extends Exercise {
+  id: string
+}
+
 export default function Exercises() {
-    return (
-        <div>Exercises</div>
-    )
+  const [exercises, setExercises] = useState<ExerciseWithId[]>([])
+  const router = useRouter()
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const snap = await getDocs(collection(db, 'exercises'))
+      setExercises(snap.docs.map(d => ({ id: d.id, ...(d.data() as Exercise) })))
+    }
+    fetchData()
+  }, [])
+
+  const handleDelete = async (id: string) => {
+    if (!confirm('Удалить упражнение?')) return
+    await deleteDoc(doc(db, 'exercises', id))
+    setExercises(prev => prev.filter(e => e.id !== id))
+  }
+
+  return (
+    <div className="w-full max-w-3xl p-4 mx-auto space-y-4">
+      <h1 className="text-xl font-semibold">Упражнения</h1>
+      <button
+        onClick={() => router.push('/exercises/new')}
+        className="px-4 py-2 text-white bg-blue-600 rounded"
+      >
+        Добавить упражнение
+      </button>
+      {exercises.map(ex => (
+        <div key={ex.id} className="p-4 space-y-2 border rounded">
+          <h2 className="text-lg font-bold">{ex.title}</h2>
+          <p>{ex.description}</p>
+          <p className="text-sm text-gray-600">
+            Тема: {ex.topic} | Сложность: {ex.difficulty}
+          </p>
+          <div className="flex gap-2">
+            <button
+              onClick={() => router.push(`/exercises/${ex.id}`)}
+              className="px-3 py-1 text-white bg-green-600 rounded"
+            >
+              Открыть
+            </button>
+            <button
+              onClick={() => router.push(`/exercises/${ex.id}/edit`)}
+              className="px-3 py-1 text-white bg-blue-600 rounded"
+            >
+              Редактировать
+            </button>
+            <button
+              onClick={() => handleDelete(ex.id)}
+              className="px-3 py-1 text-white bg-red-600 rounded"
+            >
+              Удалить
+            </button>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
 }


### PR DESCRIPTION
## Summary
- implement `/exercises` page fetching exercises from Firestore
- add dynamic `/exercises/[exerciseId]` page

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68454ce8e678832faa14c258103e7240