### PR TITLE
Add React DnD provider

### DIFF
--- a/src/app/DragDropProvider.tsx
+++ b/src/app/DragDropProvider.tsx
@@ -1,0 +1,7 @@
+'use client';
+import { DndProvider } from 'react-dnd';
+import { HTML5Backend } from 'react-dnd-html5-backend';
+
+export default function DragDropProvider({ children }: { children: React.ReactNode }) {
+  return <DndProvider backend={HTML5Backend}>{children}</DndProvider>;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Link from 'next/link'
+import DragDropProvider from './DragDropProvider'
 const geistSans = Geist({
   variable: "--font-geist-sans",
   subsets: ["latin"],
@@ -27,17 +28,19 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased flex-col items-center justify-center `}
       >
-        <nav className="flex gap-4 justify-center">
-          <Link href="/">Домой</Link>
-          {/* Prefetched when the link is hovered or enters the viewport */}
-          <Link href="/videos">Видео</Link>
-          {/* No prefetching */}
-          <Link href="/exercises">Упражнения</Link>
-        </nav>
+        <DragDropProvider>
+          <nav className="flex gap-4 justify-center">
+            <Link href="/">Домой</Link>
+            {/* Prefetched when the link is hovered or enters the viewport */}
+            <Link href="/videos">Видео</Link>
+            {/* No prefetching */}
+            <Link href="/exercises">Упражнения</Link>
+          </nav>
 
-        {children}
+          {children}
+        </DragDropProvider>
 
-        
+
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- install packages via npm
- add a `DragDropProvider` client component
- wrap layout with drag and drop context

## Testing
- `npm run lint` *(fails: 'no-unused-vars' and other eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684550492b84832f81be01d899fd8c97