### PR TITLE
Port editing pages to Next.js

### DIFF
--- a/src/app/exercises/[exerciseId]/edit/page.tsx
+++ b/src/app/exercises/[exerciseId]/edit/page.tsx
@@ -1,0 +1,5 @@
+'use client'
+import ExerciseEditor from '@/components/ExerciseEditor'
+export default function EditExercisePage() {
+  return <ExerciseEditor />
+}

--- a/src/app/exercises/new/page.tsx
+++ b/src/app/exercises/new/page.tsx
@@ -1,0 +1,5 @@
+'use client'
+import ExerciseEditor from '@/components/ExerciseEditor'
+export default function NewExercisePage() {
+  return <ExerciseEditor />
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -31,10 +31,9 @@ export default function RootLayout({
         <DragDropProvider>
           <nav className="flex gap-4 justify-center">
             <Link href="/">Домой</Link>
-            {/* Prefetched when the link is hovered or enters the viewport */}
             <Link href="/videos">Видео</Link>
-            {/* No prefetching */}
             <Link href="/exercises">Упражнения</Link>
+            <Link href="/upload">Загрузить видео</Link>
           </nav>
 
           {children}

--- a/src/app/upload/[videoId]/page.tsx
+++ b/src/app/upload/[videoId]/page.tsx
@@ -1,0 +1,5 @@
+'use client'
+import VideoEditor from '@/components/VideoEditor'
+export default function EditVideoPage() {
+  return <VideoEditor />
+}

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -1,0 +1,5 @@
+'use client'
+import VideoEditor from '@/components/VideoEditor'
+export default function UploadPage() {
+  return <VideoEditor />
+}

--- a/src/components/ExerciseEditor.tsx
+++ b/src/components/ExerciseEditor.tsx
@@ -1,0 +1,290 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { collection, addDoc, doc, getDoc, updateDoc } from 'firebase/firestore'
+import { useParams } from 'next/navigation'
+import { db } from '@/app/firebase'
+import type { Sentence, Exercise } from '@/types/index.types'
+
+interface SentenceForm {
+  text: string
+  rightAnswers: string
+  translations: { ru: string; en: string }
+  notes: { ru?: string; en?: string }
+}
+
+const emptyForm = (): SentenceForm => ({
+  text: '',
+  rightAnswers: '',
+  translations: { ru: '', en: '' },
+  notes: { ru: '', en: '' },
+})
+
+export default function ExerciseEditor() {
+  const params = useParams()
+  const exerciseId = (params as { exerciseId?: string }).exerciseId
+  const [forms, setForms] = useState<SentenceForm[]>([emptyForm()])
+  const [saving, setSaving] = useState(false)
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('')
+  const [topic, setTopic] = useState('')
+  const [difficulty, setDifficulty] = useState('')
+
+  const addForm = () => setForms(prev => [...prev, emptyForm()])
+
+  const updateForm = (index: number, updater: (form: SentenceForm) => SentenceForm) => {
+    setForms(prev => {
+      const updated = [...prev]
+      updated[index] = updater(updated[index])
+      return updated
+    })
+  }
+
+  const removeForm = (index: number) => setForms(prev => prev.filter((_, i) => i !== index))
+
+  const moveForm = (from: number, to: number) => {
+    setForms(prev => {
+      const arr = [...prev]
+      const [item] = arr.splice(from, 1)
+      arr.splice(to, 0, item)
+      return arr
+    })
+  }
+
+  useEffect(() => {
+    if (!exerciseId) return
+    const load = async () => {
+      if (!exerciseId) return
+
+      const snap = await getDoc(doc(db, 'exercises', exerciseId))
+      if (snap.exists()) {
+        const data = snap.data() as Exercise
+        setTitle(data.title)
+        setDescription(data.description)
+        setTopic(data.topic)
+        setDifficulty(data.difficulty)
+        setForms(
+          data.sentences.map(s => ({
+            text: s.text,
+            rightAnswers: s.rightAnswers.join('\n'),
+            translations: { ...s.translations },
+            notes: { ru: s.note?.ru || '', en: s.note?.en || '' },
+          }))
+        )
+      }
+    }
+    load()
+  }, [exerciseId])
+
+  const handleSave = async () => {
+    const payload: Sentence[] = forms.map(f => ({
+      text: f.text,
+      rightAnswers: f.rightAnswers
+        .split('\n')
+        .map(a => a.trim())
+        .filter(Boolean),
+      translations: { ...f.translations },
+      note:
+        f.notes.ru?.trim() || f.notes.en?.trim()
+          ? {
+              ru: f.notes.ru?.trim() || undefined,
+              en: f.notes.en?.trim() || undefined,
+            }
+          : null,
+    }))
+
+    setSaving(true)
+    try {
+      const exercise: Exercise = {
+        title,
+        description,
+        topic,
+        difficulty,
+        sentences: payload,
+      }
+
+      if (exerciseId) {
+        await updateDoc(doc(db, 'exercises', exerciseId), exercise as any)
+      } else {
+        await addDoc(collection(db, 'exercises'), exercise)
+        setForms([emptyForm()])
+        setTitle('')
+        setDescription('')
+        setTopic('')
+        setDifficulty('')
+      }
+      alert('Сохранено')
+    } catch (e: any) {
+      alert('Ошибка: ' + e.message)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="w-full max-w-2xl p-4 mx-auto space-y-4">
+      <h1 className="text-xl font-semibold">
+        {exerciseId ? 'Редактировать упражнение' : 'Добавить упражнение'}
+      </h1>
+      <div className="p-4 space-y-4 border rounded">
+        <div>
+          <label className="block text-sm font-medium">Заголовок</label>
+          <input
+            value={title}
+            placeholder="Заголовок"
+            onChange={e => setTitle(e.target.value)}
+            className="w-full mt-1 border-gray-300 rounded"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium">Описание</label>
+          <textarea
+            placeholder="Описание"
+            value={description}
+            onChange={e => setDescription(e.target.value)}
+            className="w-full mt-1 border-gray-300 rounded"
+            rows={3}
+          />
+        </div>
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium">Тема</label>
+            <input
+              placeholder="Тема"
+              value={topic}
+              onChange={e => setTopic(e.target.value)}
+              className="w-full mt-1 border-gray-300 rounded"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium">Сложность</label>
+            <select
+              name="difficulty"
+              value={difficulty}
+              onChange={e => setDifficulty(e.target.value)}
+              className="w-full mt-1 border-gray-300 rounded"
+            >
+              <option value="beginner">beginner</option>
+              <option value="intermediate">intermediate</option>
+              <option value="advanced">advanced</option>
+            </select>
+          </div>
+        </div>
+      </div>
+      {forms.map((form, idx) => (
+        <div key={idx} className="p-4 space-y-4 border rounded">
+          <div className="flex justify-end gap-2">
+            <button
+              onClick={() => moveForm(idx, idx - 1)}
+              disabled={idx === 0}
+              className="px-2 text-sm text-white bg-gray-500 rounded disabled:opacity-50"
+            >
+              ↑
+            </button>
+            <button
+              onClick={() => moveForm(idx, idx + 1)}
+              disabled={idx === forms.length - 1}
+              className="px-2 text-sm text-white bg-gray-500 rounded disabled:opacity-50"
+            >
+              ↓
+            </button>
+            <button
+              onClick={() => removeForm(idx)}
+              className="px-2 text-sm text-white bg-red-600 rounded"
+            >
+              Удалить
+            </button>
+          </div>
+          <div>
+            <label className="block text-sm font-medium">Текст</label>
+            <input
+              placeholder="Текст"
+              value={form.text}
+              onChange={e => updateForm(idx, f => ({ ...f, text: e.target.value }))}
+              className="w-full mt-1 border-gray-300 rounded"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium">
+              Правильные варианты (каждый на новой строке)
+            </label>
+            <textarea
+              placeholder="Правильные варианты (каждый на новой строке)"
+              value={form.rightAnswers}
+              onChange={e => updateForm(idx, f => ({ ...f, rightAnswers: e.target.value }))}
+              className="w-full mt-1 border-gray-300 rounded"
+              rows={3}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium">Перевод (RU)</label>
+            <input
+              placeholder="Перевод (RU)"
+              value={form.translations.ru}
+              onChange={e =>
+                updateForm(idx, f => ({
+                  ...f,
+                  translations: { ...f.translations, ru: e.target.value },
+                }))
+              }
+              className="w-full mt-1 border-gray-300 rounded"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium">Перевод (EN)</label>
+            <input
+              placeholder="Перевод (EN)"
+              value={form.translations.en}
+              onChange={e =>
+                updateForm(idx, f => ({
+                  ...f,
+                  translations: { ...f.translations, en: e.target.value },
+                }))
+              }
+              className="w-full mt-1 border-gray-300 rounded"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium">Примечание (RU)</label>
+            <input
+              placeholder="Примечание (RU)"
+              value={form.notes.ru}
+              onChange={e =>
+                updateForm(idx, f => ({
+                  ...f,
+                  notes: f.notes ? { ...f.notes, ru: e.target.value } : { ru: e.target.value },
+                }))
+              }
+              className="w-full mt-1 border-gray-300 rounded"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium">Note (EN)</label>
+            <input
+              placeholder="Note (EN)"
+              value={form.notes.en}
+              onChange={e =>
+                updateForm(idx, f => ({
+                  ...f,
+                  notes: { ...f.notes, en: e.target.value },
+                }))
+              }
+              className="w-full mt-1 border-gray-300 rounded"
+            />
+          </div>
+        </div>
+      ))}
+      <div className="flex gap-2">
+        <button onClick={addForm} className="px-4 py-2 text-white bg-blue-600 rounded">
+          Добавить предложение
+        </button>
+        <button
+          onClick={handleSave}
+          disabled={saving}
+          className="px-4 py-2 text-white bg-green-600 rounded"
+        >
+          {saving ? 'Сохранение...' : 'Сохранить'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -31,12 +31,12 @@ export default function VideoCard({ video }: Props) {
       </Link>
 
       {/* Кнопка "Редактировать" */}
-      <button
-        // onClick={() => navigate(`/upload/${video.videoId}`)}
+      <Link
+        href={`/upload/${video.videoId}`}
         className="absolute px-2 py-1 text-xs text-white transition bg-blue-600 rounded opacity-0 top-2 right-2 group-hover:opacity-100"
       >
         Редактировать
-      </button>
+      </Link>
     </div>
   );
 }

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -1,0 +1,217 @@
+'use client'
+import React, { useState, useEffect } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import { Language, LanguageMetaForm } from './LanguageMetaForm'
+import UploadTranscriber from './UploadTranscriber'
+import { SegmentEditor } from './SegmentEditor'
+import VideoPlayer from './VideoPlayer/VideoPlayer'
+import type { Segment, SubtitleData, VideoDoc } from '@/types/index.types'
+import { doc, getDoc, setDoc } from 'firebase/firestore'
+import { db } from '@/app/firebase'
+import { buildSentenceSegments } from './VideoPlayer/halpers'
+
+export default function VideoEditor() {
+  const params = useParams()
+  const router = useRouter()
+  const videoId = (params as { videoId?: string }).videoId
+
+  const [meta, setMeta] = useState({
+    originalLang: 'th' as Language,
+    targetLangs: [] as Language[],
+    difficulty: 'Beginner',
+    tags: '',
+  })
+  const [videoDoc, setVideoDoc] = useState<VideoDoc | null>(null)
+  const [editedSubs, setEditedSubs] = useState<SubtitleData | null>(null)
+  const [translating, setTranslating] = useState(false)
+  const [loadingDoc, setLoadingDoc] = useState(false)
+
+  useEffect(() => {
+    if (!videoId) return
+    setLoadingDoc(true)
+    ;(async () => {
+      try {
+        const docRef = doc(db, 'videos', videoId)
+        const snap = await getDoc(docRef)
+        if (!snap.exists()) {
+          alert('Видео для редактирования не найдено')
+          router.push('/')
+          return
+        }
+        const d = snap.data() as any
+
+        const loadedMeta = {
+          originalLang: (d.originalLang || 'auto') as Language,
+          targetLangs: d.targetLangs || [],
+          difficulty: d.difficulty || 'Beginner',
+          tags: Array.isArray(d.tags) ? d.tags.join(', ') : '',
+        }
+        setMeta(loadedMeta)
+
+        const loadedDoc: VideoDoc = {
+          src: d.src as string,
+          previewSrc: d.previewSrc as string,
+          originalLang: d.originalLang,
+          targetLangs: d.targetLangs,
+          difficulty: d.difficulty,
+          tags: d.tags,
+          subtitle: d.subtitle as SubtitleData,
+          name: d.name as string,
+          size: d.size as number,
+          updated: d.updated || null,
+        }
+        setVideoDoc(loadedDoc)
+        setEditedSubs(d.subtitle as SubtitleData)
+      } catch (e: any) {
+        console.error(e)
+        alert('Ошибка при загрузке видео для редактирования: ' + e.message)
+        router.push('/')
+      } finally {
+        setLoadingDoc(false)
+      }
+    })()
+  }, [videoId, router])
+
+  const handleUploadComplete = (url: string, subtitle: SubtitleData) => {
+    const docData: VideoDoc = {
+      src: url,
+      previewSrc: `${url}#t=0.1`,
+      originalLang: meta.originalLang,
+      targetLangs: meta.targetLangs,
+      difficulty: meta.difficulty,
+      tags: meta.tags
+        .split(',')
+        .map(t => t.trim())
+        .filter(t => t),
+      subtitle,
+      name: 'uploaded',
+      size: 0,
+      updated: null,
+    }
+    setVideoDoc(docData)
+    setEditedSubs(buildSentenceSegments(subtitle))
+  }
+
+  const handleTranslate = async () => {
+    if (!editedSubs || !videoDoc) return
+    setTranslating(true)
+    try {
+      const res = await fetch('http://localhost:4000/api/translate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          segments: editedSubs.segments.map(s => ({ id: s.id, text: s.text })),
+          targetLangs: videoDoc.targetLangs,
+        }),
+      })
+      if (!res.ok) throw new Error(await res.text())
+      const { segments: trSegments } = await res.json()
+
+      setEditedSubs(prev => {
+        if (!prev) return prev
+        const merged = prev.segments.map((s: Segment) => {
+          const tr = trSegments.find((t: any) => t.id === s.id)
+          return tr ? { ...s, translations: tr.translations } : s
+        })
+        return { segments: merged }
+      })
+    } catch (e: any) {
+      alert('Ошибка перевода: ' + e.message)
+    } finally {
+      setTranslating(false)
+    }
+  }
+
+  const handleSave = async () => {
+    if (!videoDoc || !editedSubs) return
+    const idToUse =
+      videoId || new URL(videoDoc.src).pathname.split('/').pop()?.split('.')[0] || ''
+    const updatedData: any = {
+      src: videoDoc.src,
+      previewSrc: videoDoc.previewSrc,
+      originalLang: meta.originalLang,
+      targetLangs: meta.targetLangs,
+      difficulty: meta.difficulty,
+      tags: meta.tags
+        .split(',')
+        .map(t => t.trim())
+        .filter(t => t),
+      subtitle: editedSubs,
+      name: videoDoc.name,
+      size: videoDoc.size,
+      updated: new Date(),
+    }
+    try {
+      await setDoc(doc(db, 'videos', idToUse), updatedData)
+      localStorage.setItem(`videoDoc_${idToUse}`, JSON.stringify(updatedData))
+      alert('Сохранено!')
+      router.push(`/video/${idToUse}`)
+    } catch (e: any) {
+      console.error(e)
+      alert('Ошибка при сохранении: ' + e.message)
+    }
+  }
+
+  return (
+    <div className="p-4 space-y-8">
+      <LanguageMetaForm
+        {...meta}
+        onChange={async fields => {
+          await setMeta(prev => ({ ...prev, ...fields }))
+          if (!videoDoc) return
+          setVideoDoc(prev => {
+            if (!prev) return prev
+            return { ...prev, targetLangs: fields.targetLangs ?? [] }
+          })
+        }}
+      />
+
+      <UploadTranscriber
+        originalLang={meta.originalLang}
+        targetLangs={meta.targetLangs}
+        difficulty={meta.difficulty}
+        tags={meta.tags
+          .split(',')
+          .map(t => t.trim())
+          .filter(t => t)}
+        onComplete={handleUploadComplete}
+        disabled={!!videoId}
+      />
+
+      {videoDoc && editedSubs && !loadingDoc && (
+        <>
+          <div className="w-full max-w-4xl mx-auto">
+            <VideoPlayer
+              src={videoDoc.src}
+              subtitles={editedSubs}
+              originalLang={videoDoc.originalLang as Language}
+            />
+          </div>
+
+          <button
+            onClick={handleTranslate}
+            disabled={translating}
+            className="px-6 py-2 text-white bg-blue-600 rounded"
+          >
+            {translating ? 'Перевод...' : 'Перевести'}
+          </button>
+
+          <SegmentEditor
+            segments={editedSubs.segments}
+            originalLang={videoDoc.originalLang as Language}
+            targetLangs={videoDoc.targetLangs}
+            onChange={newSegments =>
+              setEditedSubs(prev => (prev ? { ...prev, segments: newSegments } : null))
+            }
+          />
+
+          <button onClick={handleSave} className="px-6 py-2 mt-6 text-white bg-green-600 rounded">
+            {videoId ? 'Сохранить изменения' : 'Сохранить новое видео'}
+          </button>
+        </>
+      )}
+
+      {loadingDoc && <p className="text-gray-500">Загрузка данных видео для редактирования…</p>}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add client-side `ExerciseEditor` and `VideoEditor` components
- expose upload/edit pages for videos and exercises
- update layout navigation to link to new upload page
- link from `VideoCard` to the editor

## Testing
- `npm run lint` *(fails: several eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684553329d58832f903d17bacf6591f1