### PR TITLE
Implement Firebase auth

### DIFF
--- a/src/app/firebase.ts
+++ b/src/app/firebase.ts
@@ -1,4 +1,5 @@
 import { initializeApp } from 'firebase/app';
+import { getAuth } from 'firebase/auth';
 import { getFirestore } from 'firebase/firestore';
 import { getStorage } from 'firebase/storage';
 
@@ -11,7 +12,8 @@ const firebaseConfig = {
   appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
 };
 
-// Initialize Firebase app and Firestore
-const app = initializeApp(firebaseConfig);
+// Initialize Firebase app and services
+export const app = initializeApp(firebaseConfig);
+export const auth = getAuth(app);
 export const db = getFirestore(app);
 export const storage = getStorage(app);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,9 @@ import type { Metadata } from "next";
 import "./globals.css";
 import Link from 'next/link'
 import DragDropProvider from './DragDropProvider'
+import { AuthProvider } from '@/contexts/AuthContext'
+import ProtectedLayout from '@/components/ProtectedLayout'
+import Nav from '@/components/Nav'
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -16,18 +19,14 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className="antialiased flex-col items-center justify-center">
-        <DragDropProvider>
-          <nav className="flex gap-4 justify-center">
-            <Link href="/">Домой</Link>
-            <Link href="/videos">Видео</Link>
-            <Link href="/exercises">Упражнения</Link>
-            <Link href="/upload">Загрузить видео</Link>
-          </nav>
-
-          {children}
-        </DragDropProvider>
-
-
+        <AuthProvider>
+          <ProtectedLayout>
+            <DragDropProvider>
+              <Nav />
+              {children}
+            </DragDropProvider>
+          </ProtectedLayout>
+        </AuthProvider>
       </body>
     </html>
   );

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,55 @@
+'use client'
+import { useState } from 'react'
+import { useAuth } from '@/contexts/AuthContext'
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+
+export default function LoginPage() {
+  const { login } = useAuth()
+  const router = useRouter()
+  const [loginValue, setLoginValue] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    try {
+      await login(loginValue, password)
+      router.push('/')
+    } catch (e) {
+      setError((e as Error).message)
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-4 p-4">
+      <h1 className="text-2xl font-bold">Войти</h1>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <input
+          type="text"
+          placeholder="Логин"
+          value={loginValue}
+          onChange={(e) => setLoginValue(e.target.value)}
+          className="border p-2"
+        />
+        <input
+          type="password"
+          placeholder="Пароль"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="border p-2"
+        />
+        {error && <p className="text-red-500">{error}</p>}
+        <button type="submit" className="bg-blue-500 text-white py-2 px-4">
+          Войти
+        </button>
+      </form>
+      <p>
+        Нет аккаунта?{' '}
+        <Link href="/register" className="underline">
+          Зарегистрироваться
+        </Link>
+      </p>
+    </div>
+  )
+}

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,0 +1,71 @@
+'use client'
+import { useState } from 'react'
+import { useAuth } from '@/contexts/AuthContext'
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+
+export default function RegisterPage() {
+  const { register } = useAuth()
+  const router = useRouter()
+  const [loginValue, setLoginValue] = useState('')
+  const [password, setPassword] = useState('')
+  const [name, setName] = useState('')
+  const [age, setAge] = useState('')
+  const [error, setError] = useState('')
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    try {
+      await register(loginValue, password, name, parseInt(age, 10))
+      router.push('/')
+    } catch (e) {
+      setError((e as Error).message)
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-4 p-4">
+      <h1 className="text-2xl font-bold">Регистрация</h1>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <input
+          type="text"
+          placeholder="Логин"
+          value={loginValue}
+          onChange={(e) => setLoginValue(e.target.value)}
+          className="border p-2"
+        />
+        <input
+          type="password"
+          placeholder="Пароль"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="border p-2"
+        />
+        <input
+          type="text"
+          placeholder="Имя"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="border p-2"
+        />
+        <input
+          type="number"
+          placeholder="Возраст"
+          value={age}
+          onChange={(e) => setAge(e.target.value)}
+          className="border p-2"
+        />
+        {error && <p className="text-red-500">{error}</p>}
+        <button type="submit" className="bg-blue-500 text-white py-2 px-4">
+          Зарегистрироваться
+        </button>
+      </form>
+      <p>
+        Уже есть аккаунт?{' '}
+        <Link href="/login" className="underline">
+          Войти
+        </Link>
+      </p>
+    </div>
+  )
+}

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -1,0 +1,19 @@
+'use client'
+import Link from 'next/link'
+import { useAuth } from '@/contexts/AuthContext'
+
+export default function Nav() {
+  const { user, logout } = useAuth()
+
+  if (!user) return null
+
+  return (
+    <nav className="flex gap-4 justify-center">
+      <Link href="/">Домой</Link>
+      <Link href="/videos">Видео</Link>
+      <Link href="/exercises">Упражнения</Link>
+      <Link href="/upload">Загрузить видео</Link>
+      <button onClick={logout}>Выйти</button>
+    </nav>
+  )
+}

--- a/src/components/ProtectedLayout.tsx
+++ b/src/components/ProtectedLayout.tsx
@@ -1,0 +1,26 @@
+'use client'
+import { useAuth } from '@/contexts/AuthContext'
+import { usePathname, useRouter } from 'next/navigation'
+import { useEffect } from 'react'
+
+export default function ProtectedLayout({ children }: { children: React.ReactNode }) {
+  const { user, loading } = useAuth()
+  const router = useRouter()
+  const pathname = usePathname()
+
+  useEffect(() => {
+    if (!loading) {
+      if (!user && pathname !== '/login' && pathname !== '/register') {
+        router.push('/login')
+      } else if (user && (pathname === '/login' || pathname === '/register')) {
+        router.push('/')
+      }
+    }
+  }, [user, loading, pathname, router])
+
+  if (loading || (!user && pathname !== '/login' && pathname !== '/register')) {
+    return null
+  }
+
+  return <>{children}</>
+}

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,0 +1,55 @@
+'use client'
+import { createContext, useContext, useEffect, useState } from 'react'
+import { User, onAuthStateChanged, signInWithEmailAndPassword, createUserWithEmailAndPassword, signOut } from 'firebase/auth'
+import { auth, db } from '@/app/firebase'
+import { doc, setDoc } from 'firebase/firestore'
+
+interface AuthContextValue {
+  user: User | null
+  loading: boolean
+  login: (login: string, password: string) => Promise<void>
+  register: (login: string, password: string, name: string, age: number) => Promise<void>
+  logout: () => Promise<void>
+}
+
+const AuthContext = createContext<AuthContextValue>({
+  user: null,
+  loading: true,
+  login: async () => {},
+  register: async () => {},
+  logout: async () => {}
+})
+
+export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+  const [user, setUser] = useState<User | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const unsub = onAuthStateChanged(auth, (u) => {
+      setUser(u)
+      setLoading(false)
+    })
+    return () => unsub()
+  }, [])
+
+  const login = async (login: string, password: string) => {
+    await signInWithEmailAndPassword(auth, login, password)
+  }
+
+  const register = async (login: string, password: string, name: string, age: number) => {
+    const cred = await createUserWithEmailAndPassword(auth, login, password)
+    await setDoc(doc(db, 'users', cred.user.uid), { name, age, login })
+  }
+
+  const logout = async () => {
+    await signOut(auth)
+  }
+
+  return (
+    <AuthContext.Provider value={{ user, loading, login, register, logout }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export const useAuth = () => useContext(AuthContext)


### PR DESCRIPTION
## Summary
- add `auth` export in firebase config
- create auth context using Firebase Authentication
- protect routes and show navigation only for logged-in users
- add login and registration pages

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: missing script)*
- `npx tsc --noEmit` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_6845967e3494832fb8ef2a8b0fb0ebf8