### PR TITLE
Add profile dropdown and settings page

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import "./globals.css";
-import Link from 'next/link'
 import DragDropProvider from './DragDropProvider'
 import { AuthProvider } from '@/contexts/AuthContext'
 import ProtectedLayout from '@/components/ProtectedLayout'

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,0 +1,46 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { useAuth } from '@/contexts/AuthContext'
+import { db } from '../firebase'
+import { doc, getDoc } from 'firebase/firestore'
+
+interface UserInfo {
+  name: string
+  age: number
+  login: string
+}
+
+export default function ProfilePage() {
+  const { user } = useAuth()
+  const [info, setInfo] = useState<UserInfo | null>(null)
+
+  useEffect(() => {
+    if (!user) return
+    const load = async () => {
+      const snap = await getDoc(doc(db, 'users', user.uid))
+      if (snap.exists()) {
+        setInfo(snap.data() as UserInfo)
+      }
+    }
+    load()
+  }, [user])
+
+  if (!info) {
+    return <p className="p-4">Загрузка...</p>
+  }
+
+  return (
+    <div className="p-4 space-y-2">
+      <h1 className="text-2xl font-bold">Профиль пользователя</h1>
+      <p>
+        <strong>Имя:</strong> {info.name}
+      </p>
+      <p>
+        <strong>Возраст:</strong> {info.age}
+      </p>
+      <p>
+        <strong>Логин:</strong> {info.login}
+      </p>
+    </div>
+  )
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,52 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { useAuth } from '@/contexts/AuthContext'
+import { db } from '../firebase'
+import { doc, getDoc, updateDoc } from 'firebase/firestore'
+
+export default function SettingsPage() {
+  const { user } = useAuth()
+  const [name, setName] = useState('')
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    if (!user) return
+    const load = async () => {
+      const snap = await getDoc(doc(db, 'users', user.uid))
+      if (snap.exists()) {
+        const data = snap.data() as { name?: string }
+        setName(data.name || '')
+      }
+      setLoading(false)
+    }
+    load()
+  }, [user])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!user) return
+    await updateDoc(doc(db, 'users', user.uid), { name })
+    alert('Имя обновлено')
+  }
+
+  if (loading) return <p className="p-4">Загрузка...</p>
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-semibold">Настройки профиля</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium">Имя</label>
+          <input
+            value={name}
+            onChange={e => setName(e.target.value)}
+            className="w-full p-2 border rounded"
+          />
+        </div>
+        <button type="submit" className="px-4 py-2 text-white bg-blue-600 rounded">
+          Сохранить
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -1,19 +1,20 @@
 'use client'
 import Link from 'next/link'
 import { useAuth } from '@/contexts/AuthContext'
+import UserMenu from './UserMenu'
 
 export default function Nav() {
-  const { user, logout } = useAuth()
+  const { user } = useAuth()
 
   if (!user) return null
 
   return (
-    <nav className="flex gap-4 justify-center">
+    <nav className="flex items-center justify-center gap-4">
       <Link href="/">Домой</Link>
       <Link href="/videos">Видео</Link>
       <Link href="/exercises">Упражнения</Link>
       <Link href="/upload">Загрузить видео</Link>
-      <button onClick={logout}>Выйти</button>
+      <UserMenu />
     </nav>
   )
 }

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -1,0 +1,77 @@
+'use client'
+import { useState, useEffect, useRef } from 'react'
+import Link from 'next/link'
+import { useAuth } from '@/contexts/AuthContext'
+import { db } from '@/app/firebase'
+import { doc, getDoc } from 'firebase/firestore'
+
+export default function UserMenu() {
+  const { user, logout } = useAuth()
+  const [name, setName] = useState('')
+  const [open, setOpen] = useState(false)
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!user) return
+    const load = async () => {
+      const snap = await getDoc(doc(db, 'users', user.uid))
+      if (snap.exists()) {
+        const data = snap.data() as { name?: string }
+        setName(data.name || '')
+      }
+    }
+    load()
+  }, [user])
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (!menuRef.current?.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [])
+
+  if (!user) return null
+
+  return (
+    <div className="relative" ref={menuRef}>
+      <Link href="/profile" className="flex items-center gap-2">
+        <img
+          src={`https://i.pravatar.cc/40?u=${user.uid}`}
+          alt="avatar"
+          className="w-6 h-6 rounded-full"
+        />
+        <span>{name || user.email}</span>
+      </Link>
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="ml-1 text-xl leading-none"
+        aria-label="Меню пользователя"
+      >
+        ▼
+      </button>
+      {open && (
+        <div className="absolute right-0 z-10 mt-2 bg-white border rounded shadow">
+          <Link
+            href="/settings"
+            className="block px-4 py-2 hover:bg-gray-100"
+            onClick={() => setOpen(false)}
+          >
+            Настройки
+          </Link>
+          <button
+            onClick={() => {
+              logout()
+              setOpen(false)
+            }}
+            className="block w-full px-4 py-2 text-left hover:bg-gray-100"
+          >
+            Выход
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add user dropdown menu with profile link and actions
- show dropdown in the navigation
- add profile and settings pages for the user
- clean unused import in layout

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68465edcc884832fa84b12dd576876f5