### PR TITLE
Improve drag and drop exercise

### DIFF
--- a/src/components/SentenceReorderExercise.tsx
+++ b/src/components/SentenceReorderExercise.tsx
@@ -1,6 +1,8 @@
 // src/components/SentenceReorderExercise.tsx
 import React, { useState, useEffect, DragEvent } from 'react';
 import { tokenizeThaiSentence } from '../utils/thaiTokenizer';
+import { WordChip } from './WordChip';
+import { DropSlot } from './DropSlot';
 
 export interface ExerciseSentence {
   text: string;
@@ -30,8 +32,8 @@ interface SentenceReorderExerciseProps {
 export default function SentenceReorderExercise({ data }: SentenceReorderExerciseProps) {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [shuffledTokens, setShuffledTokens] = useState<TokenState[]>([]);
-  const [dropZone, setDropZone] = useState<TokenState[]>([]);
-  const [feedback, setFeedback] = useState<{ id: string; correct: boolean }[] | null>(null);
+  const [slots, setSlots] = useState<(TokenState | null)[]>([]);
+  const [feedback, setFeedback] = useState<boolean[] | null>(null);
 
   // Whenever currentIndex changes, re-tokenize & shuffle
   useEffect(() => {
@@ -51,76 +53,44 @@ export default function SentenceReorderExercise({ data }: SentenceReorderExercis
       [copy[i], copy[j]] = [copy[j], copy[i]];
     }
     setShuffledTokens(copy);
-    // Reset drop area & feedback
-    setDropZone([]);
+    setSlots(Array(keyed.length).fill(null));
     setFeedback(null);
   }, [currentIndex, data.sentences]);
 
-  // When user drags a token out of shuffledTokens → dropZone
-  const onDragStart = (
-    e: DragEvent<HTMLDivElement>,
-    token: TokenState,
-    source: 'shuffled' | 'drop',
-  ) => {
-    e.dataTransfer.setData('application/json', JSON.stringify({ token, source }));
-    // For Firefox compatibility
+  const onDragStart = (e: DragEvent<HTMLDivElement>, index: number) => {
+    e.dataTransfer.setData('text/plain', String(index));
     e.dataTransfer.effectAllowed = 'move';
   };
 
   const onDragOver = (e: DragEvent<HTMLDivElement>) => {
     e.preventDefault();
-    e.dataTransfer.dropEffect = 'move';
   };
 
-  const onDropToDropZone = (e: DragEvent<HTMLDivElement>) => {
-    e.preventDefault();
-    const payload = JSON.parse(e.dataTransfer.getData('application/json')) as {
-      token: TokenState;
-      source: 'shuffled' | 'drop';
-    };
-
-    // Remove token from its source list
-    if (payload.source === 'shuffled') {
-      setShuffledTokens(prev => prev.filter(t => t.id !== payload.token.id));
-      setDropZone(prev => [...prev, payload.token]);
-    } else {
-      // If dragging from dropZone back to dropZone? ignore
-    }
+  const onDropWord = (slotIdx: number, wordIdx: number) => {
+    setShuffledTokens(prev => {
+      const word = prev[wordIdx];
+      const remaining = prev.filter((_, i) => i !== wordIdx);
+      setSlots(sPrev => {
+        const updated = [...sPrev];
+        const replaced = updated[slotIdx];
+        updated[slotIdx] = word;
+        if (replaced) remaining.push(replaced);
+        return updated;
+      });
+      return remaining;
+    });
     setFeedback(null);
-  };
-
-  const onDropToShuffled = (e: DragEvent<HTMLDivElement>) => {
-    e.preventDefault();
-    const payload = JSON.parse(e.dataTransfer.getData('application/json')) as {
-      token: TokenState;
-      source: 'shuffled' | 'drop';
-    };
-
-    if (payload.source === 'drop') {
-      setDropZone(prev => prev.filter(t => t.id !== payload.token.id));
-      setShuffledTokens(prev => [...prev, payload.token]);
-      setFeedback(null);
-    }
-    // If dragging within shuffled, ignore
   };
 
   const checkAnswer = () => {
     const sentenceObj = data.sentences[currentIndex];
-    // Build user string by concatenating dropZone tokens in order:
-    const userJoined = dropZone.map(t => t.text).join('');
-    // Compare against each rightAnswers (they are strings)
+    const userJoined = slots.map(s => s?.text || '').join('');
     const isCorrect = sentenceObj.rightAnswers.includes(userJoined);
-
-    // prepare feedback: for each token in dropZone, mark correct position/incorrect
-    const correctTokens: { id: string; correct: boolean }[] = dropZone.map((t, idx) => {
-      // Check if t.text in the “correct token list” at this idx.
-      // We need to split the “rightAnswers[0]” into tokens in identical fashion, then compare text by position.
-      const rightTokens = tokenizeThaiSentence(sentenceObj.rightAnswers[0]);
-      const isTokenCorrect = idx < rightTokens.length && t.text === rightTokens[idx];
-      return { id: t.id, correct: isCorrect && isTokenCorrect };
+    const rightTokens = tokenizeThaiSentence(sentenceObj.rightAnswers[0]);
+    const fb = slots.map((tok, idx) => {
+      return tok ? isCorrect && tok.text === rightTokens[idx] : false;
     });
-
-    setFeedback(correctTokens);
+    setFeedback(fb);
   };
 
   const goToNext = () => {
@@ -156,57 +126,33 @@ export default function SentenceReorderExercise({ data }: SentenceReorderExercis
         <div
           className="flex flex-wrap gap-2 p-2 border border-dashed border-gray-400 rounded min-h-[3rem]"
           onDragOver={onDragOver}
-          onDrop={onDropToShuffled}
         >
-          {shuffledTokens.map(tok => {
-            const isWrong = feedback?.find(fb => fb.id === tok.id && fb.correct === false);
-            const isRight = feedback?.find(fb => fb.id === tok.id && fb.correct === true);
-            return (
-              <div
-                key={tok.id}
-                draggable
-                onDragStart={e => onDragStart(e, tok, 'shuffled')}
-                className={`px-2 py-1 rounded cursor-move select-none border ${
-                  isRight
-                    ? 'bg-green-200 border-green-400'
-                    : isWrong
-                      ? 'bg-red-200 border-red-400'
-                      : 'bg-white border-gray-300'
-                }`}
-              >
-                {tok.text}
-              </div>
-            );
-          })}
+          {shuffledTokens.map((tok, idx) => (
+            <WordChip
+              key={tok.id}
+              word={tok.text}
+              index={idx}
+              onDragStart={onDragStart}
+              onClick={() => {
+                const emptyIdx = slots.findIndex(s => s === null);
+                if (emptyIdx !== -1) onDropWord(emptyIdx, idx);
+              }}
+              isPlaced={false}
+            />
+          ))}
         </div>
 
-        {/* Drop zone */}
-        <div
-          className="flex flex-wrap gap-2 p-2 border border-dashed border-blue-400 rounded min-h-[3rem] bg-blue-50"
-          onDragOver={onDragOver}
-          onDrop={onDropToDropZone}
-        >
-          {dropZone.map(tok => {
-            const fb = feedback?.find(fb => fb.id === tok.id);
-            const isRight = fb?.correct === true;
-            const isWrong = fb?.correct === false;
-            return (
-              <div
-                key={tok.id}
-                draggable
-                onDragStart={e => onDragStart(e, tok, 'drop')}
-                className={`px-2 py-1 rounded cursor-move select-none border ${
-                  isRight
-                    ? 'bg-green-200 border-green-400'
-                    : isWrong
-                      ? 'bg-red-200 border-red-400'
-                      : 'bg-white border-blue-300'
-                }`}
-              >
-                {tok.text}
-              </div>
-            );
-          })}
+        {/* Drop slots */}
+        <div className="flex flex-wrap gap-2 p-2 border border-dashed border-blue-400 rounded min-h-[3rem] bg-blue-50">
+          {slots.map((slot, idx) => (
+            <DropSlot
+              key={idx}
+              slotIndex={idx}
+              placedWordText={slot?.text || ''}
+              onDropWord={onDropWord}
+              isCorrect={feedback ? feedback[idx] : undefined}
+            />
+          ))}
         </div>
 
         <div className="flex space-x-4">

--- a/src/components/WordChip.tsx
+++ b/src/components/WordChip.tsx
@@ -15,6 +15,7 @@ interface WordChipProps {
   word: string;
   index: number;
   onDragStart: (ev: DragEvent<HTMLDivElement>, index: number) => void;
+  onClick?: () => void;
   isPlaced: boolean; // true, если слово уже помещено в “слот”
   isCorrect?: boolean; // undefined (не проверяли), true (правильно), false (неправильно)
 }
@@ -23,6 +24,7 @@ export const WordChip: React.FC<WordChipProps> = ({
   word,
   index,
   onDragStart,
+  onClick,
   isPlaced,
   isCorrect,
 }) => {
@@ -43,6 +45,9 @@ export const WordChip: React.FC<WordChipProps> = ({
       onDragStart={e => {
         // Если уже помещено, не разрешаем drag
         if (!isPlaced) onDragStart(e, index);
+      }}
+      onClick={() => {
+        if (!isPlaced && onClick) onClick();
       }}
       data-interactive="true"
     >


### PR DESCRIPTION
## Summary
- allow WordChip to be clicked for quick placement
- rework SentenceReorderExercise to use dedicated drop slots
- replace previous drop zone logic

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_684715c6794c832fa94b56daa5d57f36