### PR TITLE
Add Thai word tooltip with info API

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,8 @@ import DragDropProvider from './DragDropProvider'
 import { AuthProvider } from '@/contexts/AuthContext'
 import ProtectedLayout from '@/components/ProtectedLayout'
 import Nav from '@/components/Nav'
+import { TooltipProvider } from '@/contexts/TooltipContext'
+import { WordTooltip } from '@/components/WordTooltip'
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -20,10 +22,13 @@ export default function RootLayout({
       <body className="antialiased flex-col items-center justify-center">
         <AuthProvider>
           <ProtectedLayout>
-            <DragDropProvider>
-              <Nav />
-              {children}
-            </DragDropProvider>
+            <TooltipProvider>
+              <DragDropProvider>
+                <Nav />
+                {children}
+                <WordTooltip />
+              </DragDropProvider>
+            </TooltipProvider>
           </ProtectedLayout>
         </AuthProvider>
       </body>

--- a/src/components/VideoPlayer/VideoPlayer.tsx
+++ b/src/components/VideoPlayer/VideoPlayer.tsx
@@ -1,8 +1,8 @@
 // src/components/VideoPlayer/VideoPlayer.tsx
-import { useRef, useState, useEffect, PointerEvent as PE, ChangeEvent } from 'react';
-import type { Segment, SubtitleData, Word } from '@/types/index.types';
-import type { Language } from '../LanguageMetaForm';
-// import { useTooltipContext } from '../../contexts/TooltipContext';
+import { useRef, useState, useEffect, PointerEvent as PE, ChangeEvent, MouseEvent } from 'react'
+import type { Segment, SubtitleData, Word } from '@/types/index.types'
+import type { Language } from '../LanguageMetaForm'
+import { useTooltipContext } from '../../contexts/TooltipContext'
 
 export type VideoDoc = {
   src: string; // URL или blob-URL
@@ -32,9 +32,9 @@ export default function VideoPlayer({ subtitles, src, originalLang }: VideoPlaye
   const [isPlaying, setIsPlaying] = useState(false);
   const [duration, setDuration] = useState(0);
   const [currentTime, setCurrentTime] = useState(0);
-  const [volume, setVolume] = useState(1);
+  const [volume, setVolume] = useState(1)
 
-  // const { showTooltip } = useTooltipContext();
+  const { showTooltip } = useTooltipContext()
 
   // Используем готовые сегменты напрямую
   const sentenceSubs = subtitles;
@@ -181,7 +181,19 @@ export default function VideoPlayer({ subtitles, src, originalLang }: VideoPlaye
             <span
               data-interactive="true"
               key={i}
-              // onClick={(e: MouseEvent<HTMLSpanElement>) => showTooltip(w.word, e, originalLang)}
+              onClick={(e: MouseEvent<HTMLSpanElement>) => {
+                const rect = e.currentTarget.getBoundingClientRect()
+                showTooltip({
+                  word: w.word,
+                  originalLang,
+                  coords: {
+                    x: rect.left + rect.width / 2 + window.scrollX,
+                    yAbove: rect.top + window.scrollY,
+                    yBelow: rect.bottom + window.scrollY,
+                  },
+                  visible: true,
+                })
+              }}
               className={`text-white cursor-pointer hover:text-blue-300 ${w.word === ' ' ? 'mr-3' : ''}`}
             >
               {w.word}

--- a/src/components/WordTooltip.tsx
+++ b/src/components/WordTooltip.tsx
@@ -1,12 +1,18 @@
 // src/components/WordTooltip.tsx
-import React, { useEffect, useState, useRef, useMemo } from 'react';
-// import type { Language } from '@/types/index.types';
-import { useTooltipContext } from '../contexts/TooltipContext';
+import React, { useEffect, useState, useRef, useMemo } from 'react'
+import { useTooltipContext } from '../contexts/TooltipContext'
 
-interface WordInfo {
-  translation: string;
-  examples: string[];
+interface ThaiInfo {
+  romanized: string
+  wordTones: { word: string; tone: string }[]
+  pos: { text: string; tag: string }[]
+  translations: Record<string, string>
+  examples: { text: string; translations: Record<string, string> }[]
 }
+
+type WordInfo =
+  | { type: 'th'; data: ThaiInfo }
+  | { type: 'en'; translation: string; examples: string[] }
 
 export function WordTooltip() {
   const { tooltip, hideTooltip } = useTooltipContext();
@@ -36,16 +42,15 @@ export function WordTooltip() {
     (async () => {
       try {
         if (originalLang === 'th') {
-          const res = await fetch(
-            `https://longdo-json.herokuapp.com/?dict=longdo&word=${encodeURIComponent(word)}`,
-          );
-          if (!res.ok) throw new Error('Ошибка при получении Longdo-данных');
-          const data = await res.json();
-          const meaning = data.meanings?.[0] || {};
-          const translation = meaning.definition || '—';
-          const examples = meaning.examples || [];
+          const res = await fetch('/api/thai-info', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ text: word }),
+          })
+          if (!res.ok) throw new Error('Ошибка при получении данных')
+          const data: ThaiInfo = await res.json()
           if (!cancelled) {
-            setWordInfo({ translation, examples });
+            setWordInfo({ type: 'th', data })
           }
         } else {
           const res = await fetch(
@@ -59,12 +64,12 @@ export function WordTooltip() {
           const translation = defObj.definition || '—';
           const examples = defObj.example ? [defObj.example] : [];
           if (!cancelled) {
-            setWordInfo({ translation, examples });
+            setWordInfo({ type: 'en', translation, examples });
           }
         }
       } catch {
         if (!cancelled) {
-          setWordInfo({ translation: 'Не удалось получить', examples: [] });
+          setWordInfo({ type: 'en', translation: 'Не удалось получить', examples: [] });
         }
       } finally {
         if (!cancelled) {
@@ -122,21 +127,84 @@ export function WordTooltip() {
       {loading ? (
         <p className="mt-2 text-sm">Загрузка...</p>
       ) : wordInfo ? (
-        <>
-          <p className="mt-2 text-sm">
-            <strong>Перевод:</strong> {wordInfo.translation}
-          </p>
-          {wordInfo.examples.length > 0 && (
-            <div className="mt-2 text-sm">
-              <strong>Примеры:</strong>
-              <ul className="ml-4 list-disc list-inside">
-                {wordInfo.examples.map((ex, i) => (
-                  <li key={i}>{ex}</li>
-                ))}
-              </ul>
-            </div>
-          )}
-        </>
+        wordInfo.type === 'th' ? (
+          <div className="mt-2 text-sm space-y-2">
+            <p>
+              <strong>Romanization:</strong> {wordInfo.data.romanized}
+            </p>
+            {Object.keys(wordInfo.data.translations).length > 0 && (
+              <div>
+                <strong>Translations:</strong>
+                <ul className="ml-4 list-disc list-inside">
+                  {Object.entries(wordInfo.data.translations).map(([lang, text]) => (
+                    <li key={lang}>
+                      {lang}: {text}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {wordInfo.data.wordTones.length > 0 && (
+              <div>
+                <strong>Tones:</strong>
+                <ul className="ml-4 list-disc list-inside">
+                  {wordInfo.data.wordTones.map((wt, i) => (
+                    <li key={i}>
+                      {wt.word} - {wt.tone}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {wordInfo.data.pos.length > 0 && (
+              <div>
+                <strong>POS:</strong>
+                <ul className="ml-4 list-disc list-inside">
+                  {wordInfo.data.pos.map((p, i) => (
+                    <li key={i}>
+                      {p.text} - {p.tag}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {wordInfo.data.examples.length > 0 && (
+              <div>
+                <strong>Examples:</strong>
+                <ul className="ml-4 list-disc list-inside">
+                  {wordInfo.data.examples.map((ex, i) => (
+                    <li key={i}>
+                      {ex.text}
+                      <ul className="ml-4 list-disc list-inside">
+                        {Object.entries(ex.translations).map(([lang, txt]) => (
+                          <li key={lang}>
+                            {lang}: {txt}
+                          </li>
+                        ))}
+                      </ul>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        ) : (
+          <>
+            <p className="mt-2 text-sm">
+              <strong>Перевод:</strong> {wordInfo.translation}
+            </p>
+            {wordInfo.examples.length > 0 && (
+              <div className="mt-2 text-sm">
+                <strong>Примеры:</strong>
+                <ul className="ml-4 list-disc list-inside">
+                  {wordInfo.examples.map((ex, i) => (
+                    <li key={i}>{ex}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </>
+        )
       ) : (
         <p className="mt-2 text-sm">Нет данных</p>
       )}


### PR DESCRIPTION
## Summary
- use TooltipProvider in layout and render WordTooltip globally
- add showing word info tooltip in VideoPlayer
- fetch data from `/api/thai-info` in WordTooltip and display extra info

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684e6b4e6520832fbf65d9091c1ea8e8