### PR TITLE
Fix Thai tooltip translation

### DIFF
--- a/src/app/api/thai-info/route.ts
+++ b/src/app/api/thai-info/route.ts
@@ -54,7 +54,10 @@ export async function POST(req: Request) {
       tag: t.partOfSpeech?.tag || '',
     }))
 
-    const targetLangs = ['en', 'ru', 'zh']
+    // Google Cloud Translation API requires full BCP-47 codes for some
+    // languages. Using plain `zh` causes a 3 INVALID_ARGUMENT error, so we
+    // explicitly request Simplified Chinese with `zh-CN`.
+    const targetLangs = ['en', 'ru', 'zh-CN']
     const translations: Record<string, string> = {}
     await Promise.all(
       targetLangs.map(async lang => {


### PR DESCRIPTION
## Summary
- fix google translate usage by specifying zh-CN

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684e990a1d44832f8744c9a01a6c1b73