### PR TITLE
Catch unsupported Thai romanization

### DIFF
--- a/src/app/api/thai-info/route.ts
+++ b/src/app/api/thai-info/route.ts
@@ -21,12 +21,18 @@ export async function POST(req: Request) {
     }
 
     const parent = `projects/${projectId}/locations/global`
-    const [romanRes] = await translateClient.romanizeText({
-      parent,
-      contents: [text],
-      sourceLanguageCode: 'th',
-    })
-    const romanized = romanRes.romanizations?.[0]?.romanizedText || ''
+    let romanized = ''
+    try {
+      const [romanRes] = await translateClient.romanizeText({
+        parent,
+        contents: [text],
+        sourceLanguageCode: 'th',
+      })
+      romanized = romanRes.romanizations?.[0]?.romanizedText || ''
+    } catch (err) {
+      console.warn('romanizeText failed:', err)
+      romanized = ''
+    }
 
     // Google Cloud Translation API requires full BCP-47 codes for some
     // languages. Using plain `zh` causes a 3 INVALID_ARGUMENT error, so we


### PR DESCRIPTION
## Summary
- add try/catch around romanizeText so unsupported languages don't break the endpoint

## Testing
- `npm run lint`
- `npm run build` *(fails: Firebase config is missing)*

------
https://chatgpt.com/codex/tasks/task_e_684edcb1d0fc832fba15833b169d7d8e