### PR TITLE
Fix tooltip for missing Thai data

### DIFF
--- a/src/app/api/thai-info/route.ts
+++ b/src/app/api/thai-info/route.ts
@@ -21,12 +21,18 @@ export async function POST(req: Request) {
     }
 
     const parent = `projects/${projectId}/locations/global`
-    const [romanRes] = await translateClient.romanizeText({
-      parent,
-      contents: [text],
-      sourceLanguageCode: 'th',
-    })
-    const romanized = romanRes.romanizations?.[0]?.romanizedText || ''
+    let romanized = ''
+    try {
+      const [romanRes] = await translateClient.romanizeText({
+        parent,
+        contents: [text],
+        sourceLanguageCode: 'th',
+      })
+      romanized = romanRes.romanizations?.[0]?.romanizedText || ''
+    } catch (err) {
+      console.warn('romanizeText failed:', err)
+      romanized = ''
+    }
 
     // Google Cloud Translation API requires full BCP-47 codes for some
     // languages. Using plain `zh` causes a 3 INVALID_ARGUMENT error, so we

--- a/src/components/WordTooltip.tsx
+++ b/src/components/WordTooltip.tsx
@@ -6,8 +6,8 @@ import { useTooltipContext } from '../contexts/TooltipContext'
 
 interface ThaiInfo {
   romanized: string
-  wordTones: { word: string; tone: string }[]
-  pos: { text: string; tag: string }[]
+  wordTones?: { word: string; tone: string }[]
+  pos?: { text: string; tag: string }[]
   translations: Record<string, string>
   examples: { text: string; translations: Record<string, string> }[]
 }
@@ -146,7 +146,7 @@ export function WordTooltip() {
                 </ul>
               </div>
             )}
-            {wordInfo.data.wordTones.length > 0 && (
+            {wordInfo.data.wordTones && wordInfo.data.wordTones.length > 0 && (
               <div>
                 <strong>Tones:</strong>
                 <ul className="ml-4 list-disc list-inside">
@@ -158,7 +158,7 @@ export function WordTooltip() {
                 </ul>
               </div>
             )}
-            {wordInfo.data.pos.length > 0 && (
+            {wordInfo.data.pos && wordInfo.data.pos.length > 0 && (
               <div>
                 <strong>POS:</strong>
                 <ul className="ml-4 list-disc list-inside">


### PR DESCRIPTION
## Summary
- treat Thai word arrays as optional in the tooltip
- guard checks against undefined

## Testing
- `npm run lint`
- `npm run build` *(fails: Firebase config is missing)*

------
https://chatgpt.com/codex/tasks/task_e_684edcb1d0fc832fba15833b169d7d8e